### PR TITLE
add  --library_path option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ python = ">=3.6"
 
 [tool.poetry.dependencies]
 python = ">=3.6"
-clang = ">=14.0.0"
+clang = "==14.0.0"
 pygments = ">=2.0.0"
+pyyaml = ">=5.4.1"
 
 [tool.poetry.scripts]
 clang-callgraph = "clang_callgraph:main"


### PR DESCRIPTION
In Ubuntu22.04 or 24.04, It seem like we couldn't using default name  `libclang.so`. same result just like below
```python
>>> import ctypes                          
>>> ctypes.cdll.LoadLibrary("libclang.so") 
OSError: libclang.so: cannot open shared object file: No such file or directory
```

by adding these option, now we could specify the llvm path like this
`clang-callgraph --library_path /usr/lib/llvm-14/lib/ compiledb.json`

and some other minor tweak